### PR TITLE
adding queries and metrics for image occurrence OMOP table

### DIFF
--- a/src/R/all_function.R
+++ b/src/R/all_function.R
@@ -473,3 +473,43 @@ create_gt_table_v1 <- function(data, columns, labels, title_text = "", subtitle_
   
   return(gt_table)
 }
+
+### table with the tab
+create_gt_table_v2 <- function(data, columns, labels, title_text = "", subtitle_text = "", footnote_text = "", pt_column = NULL) {
+  col_exprs <- rlang::syms(columns)
+  names(labels) <- columns
+  
+  gt_table <- data %>%
+    select(!!!col_exprs) %>%
+    gt() %>%
+    cols_label(!!!labels) %>%
+    tab_header(title = title_text, subtitle = subtitle_text) %>%
+    fmt_number(columns = where(is.numeric), decimals = 0) %>%
+    cols_align(align = "left", columns = vars(!!!columns[1])) %>%
+    tab_options(
+      table.font.size = px(14),
+      heading.align = "left",
+      table.border.top.color = "darkred",
+      table.align = "left"
+    ) %>%
+    opt_row_striping() %>%
+    tab_footnote(footnote = footnote_text) %>%
+    tab_style(
+      style = list(cell_text(weight = "bold")),
+      locations = cells_column_labels()
+    ) %>%
+    tab_style(
+      style = list(cell_text(size = px(16))),
+      locations = cells_column_labels()
+    )
+  
+  # Add tab spanner for pt_column if provided
+  if (!is.null(pt_column)) {
+    gt_table <- gt_table %>%
+      tab_spanner(
+        label = "Patient Info",
+        columns = vars(!!rlang::sym(pt_column)))
+  }
+  
+  return(gt_table)
+}

--- a/src/feb_2025/demographic_clinical.qmd
+++ b/src/feb_2025/demographic_clinical.qmd
@@ -243,6 +243,11 @@ path_tc_img <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic/
 tc_img <- fetch_data_from_sql_file(path_tc_img, yaml_file_path)
 tc_img
 ```
+```{r, message=FALSE, warning=FALSE, results='hide'}
+path_tc_tb_img <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic/scr_thoracic_tb_image_occ.sql"
+tc_img_tb <- fetch_data_from_sql_file(path_tc_tb_img, yaml_file_path)
+tc_img_tb
+```
 
 ```{r,message=FALSE, warning=FALSE, results='hide'}
 ## to be coded later ##

--- a/src/feb_2025/demographic_clinical.qmd
+++ b/src/feb_2025/demographic_clinical.qmd
@@ -342,3 +342,97 @@ create_gt_table_v1(
 ```
 
 
+### **OMOP Image Occurrence**
+
+As of the February 2025 oncology OMOP population, 93,333 (60%) out of 201,554 patients in the oncology cohort had image occurrence procedures recorded.
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+sql_file_path_image <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_person.sql"
+res_img <- fetch_data_from_sql_file(sql_file_path_image, yaml_file_path)
+print(res_img)
+den_series=as.numeric(res_img$counts)[2]
+den_pts=as.numeric(res_img$counts)[1]
+
+```
+
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+sql_file_path_image_mod <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_modality.sql"
+res_img_mod <- fetch_data_from_sql_file(sql_file_path_image_mod, yaml_file_path)
+print(res_img_mod)
+res_img_mod=res_img_mod[1:50,]
+```
+
+
+```{r message=FALSE, warning=FALSE, results='hide'}
+res_img_mod <- res_img_mod %>%
+  mutate(
+    N_perc_series = calculate_N_percent(series_count, den=den_series),
+    N_perc_pts=calculate_N_percent(unique_person_count, den=den_pts)
+  )
+print(res_img_mod)
+```
+
+```{r, message=FALSE, warning=FALSE}
+labels <- c(
+  "modality_source_value"="Modality Type",
+  "N_perc_series" = "Series N(%)",
+   "N_perc_pts" = "Patient N(%)"
+)
+
+create_gt_table_v1(
+  data = res_img_mod, 
+  columns = c( "modality_source_value","N_perc_series", "N_perc_pts"), 
+  labels = labels, 
+   subtitle_text = "Presenting top 50 modality sites",
+  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
+
+```
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+sql_file_path_image_anat <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_anatomic.sql"
+res_img_anat <- fetch_data_from_sql_file(sql_file_path_image_anat, yaml_file_path)
+print(res_img_anat)
+res_img_anat=res_img_anat[1:50,]
+```
+```{r message=FALSE, warning=FALSE, results='hide'}
+res_img_anat <- res_img_anat %>%
+  mutate(
+    N_perc_series = calculate_N_percent(series_count, den=den_series),
+    N_perc_pts=calculate_N_percent(unique_person_count, den=den_pts)
+  )
+print(res_img_anat)
+```
+```{r, message=FALSE, warning=FALSE}
+labels <- c(
+  "anatomic_site_source_value"="Anatomic Site",
+  "N_perc_series" = "Series N(%)",
+   "N_perc_pts" = "Patient N(%)"
+)
+
+create_gt_table_v1(
+  data = res_img_anat, 
+  columns = c( "anatomic_site_source_value","N_perc_series", "N_perc_pts"), 
+  labels = labels, 
+  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
+
+```
+
+
+```{r, message=FALSE, warning=FALSE}
+labels <- c(
+  "anatomic_site_source_value"="Anatomic Site",
+  "N_perc_series" = "Series N(%)",
+   "N_perc_pts" = "Patient N(%)"
+)
+
+create_gt_table_v1(
+  data = res_img_anat, 
+  columns = c( "anatomic_site_source_value","N_perc_series", "N_perc_pts"), 
+  labels = labels, 
+ subtitle_text = "Presenting top 50 anatomic sites",
+  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
+
+```
+
+

--- a/src/feb_2025/demographic_clinical.qmd
+++ b/src/feb_2025/demographic_clinical.qmd
@@ -234,31 +234,47 @@ create_gt_table_v1(
 
 ### **OMOP Image Occurrence**
 
-As of the February 2025 oncology OMOP population, 93,333 out of 201,554 patients in the oncology cohort had image occurrence procedures recorded.
-From 13,379 thoracic patients 6,736 (50%) image occurrence procedures were recorded.
-
+```{r, message=FALSE, warning=FALSE, results='hide'}
+path_img <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_person.sql"
+pt_img <- fetch_data_from_sql_file(path_img, yaml_file_path)
+pt_img
+```
 
 ```{r, message=FALSE, warning=FALSE, results='hide'}
+path_tc <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic/scr_thoracic_person_metrics.sql"
+tc_pts <- fetch_data_from_sql_file(path_tc, yaml_file_path)
+tc_pts
+```
+```{r, message=FALSE, warning=FALSE, results='hide'}
+##thoracic cohort
 path_tc_img <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic/scr_thoracic_nf_image_occ.sql"
 tc_img <- fetch_data_from_sql_file(path_tc_img, yaml_file_path)
 tc_img
 ```
+
 ```{r, message=FALSE, warning=FALSE, results='hide'}
-path_tc_tb_img <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic/scr_thoracic_tb_image_occ.sql"
-tc_img_tb <- fetch_data_from_sql_file(path_tc_tb_img, yaml_file_path)
-tc_img_tb
+## tb thoracic with imaging
+path_tc_tb <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic/scr_thoracic_tb_image_occ.sql"
+tc_img_tb <- fetch_data_from_sql_file(path_tc_tb, yaml_file_path)
+tc_img_tb ##2435
+```
+```{r, message=FALSE, warning=FALSE, results='hide'}
+## tb thoracic 
+path_tb <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic/scr_thoracic_tb_metrics.sql"
+tc_tb <- fetch_data_from_sql_file(path_tb, yaml_file_path)
+tc_tb
 ```
 
-```{r,message=FALSE, warning=FALSE, results='hide'}
-## to be coded later ##
-thoracic_patients <- 13379
-thoracic_image_occurrence <- 6736
-thoracic_image_percentage <- (thoracic_image_occurrence / thoracic_patients) * 100
+As of the February 2025 oncology OMOP population:
 
-cat(paste0("From ", format(thoracic_patients, big.mark = ","), " thoracic patients, ", 
-       format(thoracic_image_occurrence, big.mark = ","), " (", 
-       round(thoracic_image_percentage, 1), "%) had image occurrence."))
-```
+- `r format(pt_img$counts[1], big.mark = ",")` (`r round(pt_img$counts[1] / den_arpah * 100, 1)`%) out of `r format(den_arpah, big.mark = ",")` patients in the oncology cohort had image occurrence procedures recorded.
+
+- `r format(tc_img$patient_count, big.mark = ",")` (`r round(tc_img$patient_count / tc_pts$patient_count * 100, 1)`%) out of `r format(tc_pts$patient_count, big.mark = ",")` thoracic patients had  image occurrence procedures were recorded.
+
+- `r format(tc_img_tb$patient_count, big.mark = ",")` (`r round(tc_img_tb$patient_count / tc_tb$patient_count * 100, 1)`%) out of `r format(tc_tb$patient_count, big.mark = ",")` thoracic patients with tumor board encounter had  image occurrence procedures were recorded.
+
+
+
 
 ```{r, message=FALSE, warning=FALSE, results='hide'}
 sql_file_path_image <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_person.sql"
@@ -350,7 +366,7 @@ create_gt_table_v1(
 ```
 
 
-```{r}
+```{r, message=FALSE, warning=FALSE, results='hide'}
 # Pivot data for ggplot
 library(ggplot2)
 library(plotly)

--- a/src/feb_2025/demographic_clinical.qmd
+++ b/src/feb_2025/demographic_clinical.qmd
@@ -192,6 +192,8 @@ create_gt_table_v1(
 
 The following metrics were identified for individuals with thoracic cancer within the oncology OMOP (200k).
 
+
+
 ```{r, message=FALSE, warning=FALSE, results='hide'}
 folder_path_tc <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic"
 res_tc <- fetch_data_from_sql_folder(folder_path_tc)
@@ -228,6 +230,165 @@ create_gt_table_v1(
 )
 
 ```
+
+
+### **OMOP Image Occurrence**
+
+As of the February 2025 oncology OMOP population, 93,333 out of 201,554 patients in the oncology cohort had image occurrence procedures recorded.
+From 13,379 thoracic patients 6,736 (50%) image occurrence procedures were recorded.
+
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+path_tc_img <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/scr/thoracic/scr_thoracic_nf_image_occ.sql"
+tc_img <- fetch_data_from_sql_file(path_tc_img, yaml_file_path)
+tc_img
+```
+
+```{r,message=FALSE, warning=FALSE, results='hide'}
+## to be coded later ##
+thoracic_patients <- 13379
+thoracic_image_occurrence <- 6736
+thoracic_image_percentage <- (thoracic_image_occurrence / thoracic_patients) * 100
+
+cat(paste0("From ", format(thoracic_patients, big.mark = ","), " thoracic patients, ", 
+       format(thoracic_image_occurrence, big.mark = ","), " (", 
+       round(thoracic_image_percentage, 1), "%) had image occurrence."))
+```
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+sql_file_path_image <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_person.sql"
+res_img <- fetch_data_from_sql_file(sql_file_path_image, yaml_file_path)
+print(res_img)
+den_series=as.numeric(res_img$counts)[2]
+den_pts=as.numeric(res_img$counts)[1]
+
+```
+
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+sql_file_path_image_mod <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_modality.sql"
+res_img_mod <- fetch_data_from_sql_file(sql_file_path_image_mod, yaml_file_path)
+print(res_img_mod)
+res_img_mod=res_img_mod[1:50,]
+```
+
+
+```{r message=FALSE, warning=FALSE, results='hide'}
+res_img_mod <- res_img_mod %>%
+  mutate(
+    N_perc_series = calculate_N_percent(series_count, den=den_series),
+    N_perc_pts=calculate_N_percent(unique_person_count, den=den_pts)
+  )
+print(res_img_mod)
+```
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+labels <- c(
+  "modality_source_value"="Modality Type",
+  "N_perc_series" = "Series N(%)",
+   "N_perc_pts" = "Patient N(%)"
+)
+
+create_gt_table_v1(
+  data = res_img_mod, 
+  columns = c( "modality_source_value","N_perc_series", "N_perc_pts"), 
+  labels = labels, 
+   subtitle_text = "Presenting top 50 modality sites",
+  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
+
+```
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+sql_file_path_image_anat <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_anatomic.sql"
+res_img_anat <- fetch_data_from_sql_file(sql_file_path_image_anat, yaml_file_path)
+print(res_img_anat)
+res_img_anat=res_img_anat[1:50,]
+```
+```{r message=FALSE, warning=FALSE, results='hide'}
+res_img_anat <- res_img_anat %>%
+  mutate(
+    N_perc_series = calculate_N_percent(series_count, den=den_series),
+    N_perc_pts=calculate_N_percent(unique_person_count, den=den_pts)
+  )
+print(res_img_anat)
+```
+```{r, message=FALSE, warning=FALSE, results='hide'}
+labels <- c(
+  "anatomic_site_source_value"="Anatomic Site",
+  "N_perc_series" = "Series N(%)",
+   "N_perc_pts" = "Patient N(%)"
+)
+
+create_gt_table_v1(
+  data = res_img_anat, 
+  columns = c( "anatomic_site_source_value","N_perc_series", "N_perc_pts"), 
+  labels = labels, 
+  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
+
+```
+
+
+```{r, message=FALSE, warning=FALSE, results='hide'}
+labels <- c(
+  "anatomic_site_source_value"="Anatomic Site",
+  "N_perc_series" = "Series N(%)",
+   "N_perc_pts" = "Patient N(%)"
+)
+
+create_gt_table_v1(
+  data = res_img_anat, 
+  columns = c( "anatomic_site_source_value","N_perc_series", "N_perc_pts"), 
+  labels = labels, 
+ subtitle_text = "Presenting top 50 anatomic sites",
+  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
+
+```
+
+
+```{r}
+# Pivot data for ggplot
+library(ggplot2)
+library(plotly)
+library(dplyr)
+
+# Sort data by N_perc_pts (descending)
+plot_data <- res_img_anat %>%
+  select(anatomic_site_source_value, N_perc_series, N_perc_pts, unique_person_count) %>%
+  arrange(desc(unique_person_count))
+
+plot_data$anatomic_site_source_value <- factor(plot_data$anatomic_site_source_value, 
+levels = plot_data$anatomic_site_source_value)
+```
+```{r}
+# Create the dynamic bar plot
+fig <- plot_ly(
+  data = plot_data,
+  x = ~anatomic_site_source_value,
+  y = ~N_perc_series,
+  type = "bar",
+  name = "Series N",
+  marker = list(color = "steelblue", width=3.95)
+) %>%
+  add_trace(
+    y = ~N_perc_pts,
+    name = "Patient N",
+    marker = list(color = "darkred", width=0.98)
+  ) %>%
+  layout(
+    title = "Counts for Anatomic Sites",
+    xaxis = list(title = "",  tickfont = list(size = 14),
+                titlefont = list(size = 12)),
+    yaxis = list(title = "Counts (%)", showticklabels = FALSE,  tickfont = list(size = 14),
+                titlefont = list(size = 14)),
+    barmode = "group", bargap = 0.15
+  )
+fig
+```
+
+
+
+
+
 ### **CTSA Metrics**
 
 CTSA metrics are a common set of metrics developed in collaboration with the National Center for Advancing Translational Sciences (NCATS) to compare performance against other institutions within the network, facilitate benchmarking, and measure progress in translating basic science discoveries into clinical applications and patient benefits.
@@ -341,137 +502,3 @@ create_gt_table_v1(
 
 ```
 
-
-### **OMOP Image Occurrence**
-
-As of the February 2025 oncology OMOP population, 93,333 (60%) out of 201,554 patients in the oncology cohort had image occurrence procedures recorded.
-
-```{r, message=FALSE, warning=FALSE, results='hide'}
-sql_file_path_image <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_person.sql"
-res_img <- fetch_data_from_sql_file(sql_file_path_image, yaml_file_path)
-print(res_img)
-den_series=as.numeric(res_img$counts)[2]
-den_pts=as.numeric(res_img$counts)[1]
-
-```
-
-
-```{r, message=FALSE, warning=FALSE, results='hide'}
-sql_file_path_image_mod <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_modality.sql"
-res_img_mod <- fetch_data_from_sql_file(sql_file_path_image_mod, yaml_file_path)
-print(res_img_mod)
-res_img_mod=res_img_mod[1:50,]
-```
-
-
-```{r message=FALSE, warning=FALSE, results='hide'}
-res_img_mod <- res_img_mod %>%
-  mutate(
-    N_perc_series = calculate_N_percent(series_count, den=den_series),
-    N_perc_pts=calculate_N_percent(unique_person_count, den=den_pts)
-  )
-print(res_img_mod)
-```
-
-```{r, message=FALSE, warning=FALSE}
-labels <- c(
-  "modality_source_value"="Modality Type",
-  "N_perc_series" = "Series N(%)",
-   "N_perc_pts" = "Patient N(%)"
-)
-
-create_gt_table_v1(
-  data = res_img_mod, 
-  columns = c( "modality_source_value","N_perc_series", "N_perc_pts"), 
-  labels = labels, 
-   subtitle_text = "Presenting top 50 modality sites",
-  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
-
-```
-
-```{r, message=FALSE, warning=FALSE, results='hide'}
-sql_file_path_image_anat <- "/workspaces/starr-oncology-data-lake-arpah/src/sql/image_occ/image_occ_anatomic.sql"
-res_img_anat <- fetch_data_from_sql_file(sql_file_path_image_anat, yaml_file_path)
-print(res_img_anat)
-res_img_anat=res_img_anat[1:50,]
-```
-```{r message=FALSE, warning=FALSE, results='hide'}
-res_img_anat <- res_img_anat %>%
-  mutate(
-    N_perc_series = calculate_N_percent(series_count, den=den_series),
-    N_perc_pts=calculate_N_percent(unique_person_count, den=den_pts)
-  )
-print(res_img_anat)
-```
-```{r, message=FALSE, warning=FALSE}
-labels <- c(
-  "anatomic_site_source_value"="Anatomic Site",
-  "N_perc_series" = "Series N(%)",
-   "N_perc_pts" = "Patient N(%)"
-)
-
-create_gt_table_v1(
-  data = res_img_anat, 
-  columns = c( "anatomic_site_source_value","N_perc_series", "N_perc_pts"), 
-  labels = labels, 
-  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
-
-```
-
-
-```{r, message=FALSE, warning=FALSE}
-labels <- c(
-  "anatomic_site_source_value"="Anatomic Site",
-  "N_perc_series" = "Series N(%)",
-   "N_perc_pts" = "Patient N(%)"
-)
-
-create_gt_table_v1(
-  data = res_img_anat, 
-  columns = c( "anatomic_site_source_value","N_perc_series", "N_perc_pts"), 
-  labels = labels, 
- subtitle_text = "Presenting top 50 anatomic sites",
-  footnote_text = paste0("Number of series in image_occurrence table : ", format(den_series, big.mark = ",") ))
-
-```
-
-
-```{r}
-# Pivot data for ggplot
-library(ggplot2)
-library(plotly)
-library(dplyr)
-
-# Sort data by N_perc_pts (descending)
-plot_data <- res_img_anat %>%
-  select(anatomic_site_source_value, N_perc_series, N_perc_pts, unique_person_count) %>%
-  arrange(desc(unique_person_count))
-
-plot_data$anatomic_site_source_value <- factor(plot_data$anatomic_site_source_value, 
-                                               levels = plot_data$anatomic_site_source_value)
-```
-```{r}
-# Create the dynamic bar plot
-fig <- plot_ly(
-  data = plot_data,
-  x = ~anatomic_site_source_value,
-  y = ~N_perc_series,
-  type = "bar",
-  name = "Series N",
-  marker = list(color = "steelblue", width=3.95)
-) %>%
-  add_trace(
-    y = ~N_perc_pts,
-    name = "Patient N",
-    marker = list(color = "darkred", width=0.98)
-  ) %>%
-  layout(
-    title = "Counts for Anatomic Sites",
-    xaxis = list(title = "",  tickfont = list(size = 14),
-                titlefont = list(size = 12)),
-    yaxis = list(title = "Counts (%)", showticklabels = FALSE,  tickfont = list(size = 14),
-                titlefont = list(size = 14)),
-    barmode = "group", bargap = 0.15
-  )
-fig
-```

--- a/src/feb_2025/demographic_clinical.qmd
+++ b/src/feb_2025/demographic_clinical.qmd
@@ -436,3 +436,70 @@ create_gt_table_v1(
 ```
 
 
+```{r}
+
+# Create the GT table
+res_img_anat %>%
+  gt() %>%
+  tab_header(
+    title = "Top 50 Anatomic Sites",
+    subtitle = "Presenting Series and Patient Counts"
+  ) %>%
+  cols_label(
+    anatomic_site_source_value = "Anatomic Site",
+    N_perc_series = "Series N(%)",
+    N_perc_pts = "Patient N(%)"
+  ) %>%
+  tab_spanner(
+    label = "Counts and Percentages",
+    columns = c(N_perc_series, N_perc_pts)
+  ) %>%
+  tab_options(
+    table.font.size = px(14),
+    heading.align = "left",
+    table.border.top.color = "darkred",
+    table.align = "left"
+  ) %>%
+  opt_row_striping() %>%
+  tab_footnote(
+    footnote = "Number of series in image_occurrence table.",
+    locations = cells_column_labels(columns = c(N_perc_series, N_perc_pts))
+  )
+```
+```{r}
+# Pivot data for ggplot
+library(ggplot2)
+library(plotly)
+library(dplyr)
+
+# Sort data by N_perc_pts (descending)
+plot_data <- res_img_anat %>%
+  select(anatomic_site_source_value, N_perc_series, N_perc_pts, unique_person_count) %>%
+  arrange(desc(unique_person_count))
+
+```
+```{r}
+# Create the dynamic bar plot
+fig <- plot_ly(
+  data = plot_data,
+  x = ~anatomic_site_source_value,
+  y = ~N_perc_series,
+  type = "bar",
+  name = "Series N",
+  marker = list(color = "steelblue", width=3.95)
+) %>%
+  add_trace(
+    y = ~N_perc_pts,
+    name = "Patient N",
+    marker = list(color = "darkred", width=0.98)
+  ) %>%
+  layout(
+    title = "Counts for Anatomic Sites",
+    xaxis = list(title = "",  tickfont = list(size = 14),
+                titlefont = list(size = 12)),
+    yaxis = list(title = "Counts (%)", showticklabels = FALSE,  tickfont = list(size = 14),
+                titlefont = list(size = 14)),
+    barmode = "group", bargap = 0.15
+  )
+fig
+```

--- a/src/feb_2025/demographic_clinical.qmd
+++ b/src/feb_2025/demographic_clinical.qmd
@@ -271,7 +271,7 @@ As of the February 2025 oncology OMOP population:
 
 - `r format(tc_img$patient_count, big.mark = ",")` (`r round(tc_img$patient_count / tc_pts$patient_count * 100, 1)`%) out of `r format(tc_pts$patient_count, big.mark = ",")` thoracic patients had  image occurrence procedures.
 
-- `r format(tc_img_tb$patient_count, big.mark = ",")` (`r round(tc_img_tb$patient_count / tc_tb$patient_count * 100, 1)`%) out of `r format(tc_tb$patient_count, big.mark = ",")` thoracic patients with tumor board encounter had image occurrence procedures were recorded.
+- `r format(tc_img_tb$patient_count, big.mark = ",")` (`r round(tc_img_tb$patient_count / tc_tb$patient_count * 100, 1)`%) out of `r format(tc_tb$patient_count, big.mark = ",")` thoracic patients with tumor board encounter had image occurrence procedures.
 
 
 
@@ -380,7 +380,7 @@ plot_data <- res_img_anat %>%
 plot_data$anatomic_site_source_value <- factor(plot_data$anatomic_site_source_value, 
 levels = plot_data$anatomic_site_source_value)
 ```
-```{r}
+```{r, message=FALSE, warning=FALSE, results='hide'}
 # Create the dynamic bar plot
 fig <- plot_ly(
   data = plot_data,
@@ -405,8 +405,6 @@ fig <- plot_ly(
   )
 fig
 ```
-
-
 
 
 

--- a/src/feb_2025/demographic_clinical.qmd
+++ b/src/feb_2025/demographic_clinical.qmd
@@ -267,11 +267,11 @@ tc_tb
 
 As of the February 2025 oncology OMOP population:
 
-- `r format(pt_img$counts[1], big.mark = ",")` (`r round(pt_img$counts[1] / den_arpah * 100, 1)`%) out of `r format(den_arpah, big.mark = ",")` patients in the oncology cohort had image occurrence procedures recorded.
+- `r format(pt_img$counts[1], big.mark = ",")` (`r round(pt_img$counts[1] / den_arpah * 100, 1)`%) out of `r format(den_arpah, big.mark = ",")` patients in the oncology cohort had image occurrence procedures.
 
-- `r format(tc_img$patient_count, big.mark = ",")` (`r round(tc_img$patient_count / tc_pts$patient_count * 100, 1)`%) out of `r format(tc_pts$patient_count, big.mark = ",")` thoracic patients had  image occurrence procedures were recorded.
+- `r format(tc_img$patient_count, big.mark = ",")` (`r round(tc_img$patient_count / tc_pts$patient_count * 100, 1)`%) out of `r format(tc_pts$patient_count, big.mark = ",")` thoracic patients had  image occurrence procedures.
 
-- `r format(tc_img_tb$patient_count, big.mark = ",")` (`r round(tc_img_tb$patient_count / tc_tb$patient_count * 100, 1)`%) out of `r format(tc_tb$patient_count, big.mark = ",")` thoracic patients with tumor board encounter had  image occurrence procedures were recorded.
+- `r format(tc_img_tb$patient_count, big.mark = ",")` (`r round(tc_img_tb$patient_count / tc_tb$patient_count * 100, 1)`%) out of `r format(tc_tb$patient_count, big.mark = ",")` thoracic patients with tumor board encounter had image occurrence procedures were recorded.
 
 
 

--- a/src/feb_2025/demographic_clinical.qmd
+++ b/src/feb_2025/demographic_clinical.qmd
@@ -437,36 +437,6 @@ create_gt_table_v1(
 
 
 ```{r}
-
-# Create the GT table
-res_img_anat %>%
-  gt() %>%
-  tab_header(
-    title = "Top 50 Anatomic Sites",
-    subtitle = "Presenting Series and Patient Counts"
-  ) %>%
-  cols_label(
-    anatomic_site_source_value = "Anatomic Site",
-    N_perc_series = "Series N(%)",
-    N_perc_pts = "Patient N(%)"
-  ) %>%
-  tab_spanner(
-    label = "Counts and Percentages",
-    columns = c(N_perc_series, N_perc_pts)
-  ) %>%
-  tab_options(
-    table.font.size = px(14),
-    heading.align = "left",
-    table.border.top.color = "darkred",
-    table.align = "left"
-  ) %>%
-  opt_row_striping() %>%
-  tab_footnote(
-    footnote = "Number of series in image_occurrence table.",
-    locations = cells_column_labels(columns = c(N_perc_series, N_perc_pts))
-  )
-```
-```{r}
 # Pivot data for ggplot
 library(ggplot2)
 library(plotly)
@@ -477,6 +447,8 @@ plot_data <- res_img_anat %>%
   select(anatomic_site_source_value, N_perc_series, N_perc_pts, unique_person_count) %>%
   arrange(desc(unique_person_count))
 
+plot_data$anatomic_site_source_value <- factor(plot_data$anatomic_site_source_value, 
+                                               levels = plot_data$anatomic_site_source_value)
 ```
 ```{r}
 # Create the dynamic bar plot

--- a/src/sql/image_occ/image_occ_anatomic.sql
+++ b/src/sql/image_occ/image_occ_anatomic.sql
@@ -1,0 +1,24 @@
+
+----------------------------------
+--- number of anatomic series ---
+-----------------------------------
+SELECT 
+    anatomic_site_source_value, 
+    COUNT(*) AS series_count, 
+    COUNT(DISTINCT person_id) AS unique_person_count, 
+    'Number of series in each anatomic site' AS variable_name
+FROM (
+    SELECT DISTINCT 
+        image_study_uid, 
+        image_series_uid, 
+        anatomic_site_source_value, 
+        person_id  
+    FROM 
+        `@oncology_prod.@oncology_omop.image_occurrence`
+    WHERE 
+        anatomic_site_source_value IS NOT NULL
+) AS distinct_series
+GROUP BY 
+    anatomic_site_source_value
+ORDER BY 
+    series_count DESC;

--- a/src/sql/image_occ/image_occ_modality.sql
+++ b/src/sql/image_occ/image_occ_modality.sql
@@ -1,0 +1,25 @@
+
+----------------------------------
+--- number of modality series ---
+-----------------------------------
+
+SELECT 
+    modality_source_value, 
+    COUNT(*) AS series_count, 
+    COUNT(DISTINCT person_id) AS unique_person_count, 
+    'Number of series in each modality' AS variable_name
+FROM (
+    SELECT DISTINCT 
+        image_study_uid, 
+        image_series_uid, 
+        modality_source_value, 
+        person_id  
+    FROM 
+        `@oncology_prod.@oncology_omop.image_occurrence`
+    WHERE 
+        modality_source_value IS NOT NULL
+) AS distinct_series
+GROUP BY 
+    modality_source_value
+ORDER BY 
+    series_count DESC;

--- a/src/sql/image_occ/image_occ_person.sql
+++ b/src/sql/image_occ/image_occ_person.sql
@@ -1,0 +1,15 @@
+
+--------------------------------------------------------
+--- number of unique series and number of unique pts ---
+--------------------------------------------------------
+
+SELECT COUNT(*) AS counts, 'Number of series in image_occurrence table' AS variable_name
+FROM (
+    SELECT DISTINCT image_study_uid, image_series_uid
+    FROM `@oncology_prod.@oncology_omop.image_occurrence`
+) AS distinct_series
+
+UNION ALL
+
+SELECT COUNT(DISTINCT person_id) AS counts, 'Number of unique persons in image_occurrence table' AS variable_name
+FROM `@oncology_prod.@oncology_omop.image_occurrence`;

--- a/src/sql/scr/thoracic/scr_thoracic_nf_image_occ.sql
+++ b/src/sql/scr/thoracic/scr_thoracic_nf_image_occ.sql
@@ -1,0 +1,38 @@
+----------------------------------------------------------------------------------------
+-- Number of patients in Neural Frame and diagnosed with thoracic cancer with image occur
+------------------------------------------------------------------------------------------
+with 
+person as (select * from `@oncology_prod.@oncology_omop.person`),
+image_occ as (select * from `@oncology_prod.@oncology_omop.image_occurrence`),
+scr as (select * from `@oncology_prod.@oncology_neuralframe.onc_neuralframe_case_diagnoses`),
+scr_data as
+(
+select
+distinct cleaned_nf_mrn, cleaned_nf_dob,
+primarySiteDescription
+,MIN(dateOfDiagnosis) as earliest_scr_diagnosis_date --note: not all patients have a SCR diagnosis date
+from
+scr nf
+where
+trim(medicalRecordNumber) <> ''and length(dateOfBirth) = 8
+group by cleaned_nf_mrn, cleaned_nf_dob,primarySiteDescription
+),
+scr_omop as
+(select
+ distinct
+ p.person_id,
+ p.person_source_value,
+ primarySiteDescription,
+ scr_data.earliest_scr_diagnosis_date
+from
+scr_data
+inner join person p on p.person_source_value = concat(scr_data.cleaned_nf_mrn, ' | ', scr_data.cleaned_nf_dob)
+)
+select
+count(distinct person_source_value) patient_count
+from scr_omop
+inner join image_occ using(person_id)
+where
+lower(primarysiteDescription) like '%lung%'
+or lower(primarysiteDescription) like '%bronchus%'
+or lower(primarysiteDescription) like '%thymus%'

--- a/src/sql/scr/thoracic/scr_thoracic_tb_image_occ.sql
+++ b/src/sql/scr/thoracic/scr_thoracic_tb_image_occ.sql
@@ -1,0 +1,27 @@
+with
+person as (select * from `@oncology_prod.@oncology_omop.person`),
+all_flag as (select * from `@oncology_prod.@oncology_temp.onc_arpah__cancer_cohort`),
+image_occ as (select * from `@oncology_prod.@oncology_omop.image_occurrence`),
+scr as (select * from `@oncology_prod.@oncology_neuralframe.onc_neuralframe_case_diagnoses`),
+tumor_board_patients AS (
+select person_source_value from all_flag
+where tumor_board_encounter_flag = 1
+),
+scr_thoracic_patients as (
+    select distinct
+cleaned_nf_mrn,cleaned_nf_dob
+    FROM scr
+    WHERE trim(medicalRecordNumber) <> '' and length(dateOfBirth) = 8
+    and lower(primarysiteDescription) like '%lung%'
+    or lower(primarysiteDescription) like '%bronchus%'
+    or lower(primarysiteDescription) like '%thymus%'
+    GROUP BY cleaned_nf_mrn, cleaned_nf_dob --return results at patient level
+),
+person_img as (select person_source_value from person inner join image_occ using (person_id))
+select count(distinct person_img.person_source_value) patient_count
+from
+tumor_board_patients tb
+inner join person_img on person_img.person_source_value = tb.person_source_value
+inner join scr_thoracic_patients on person_img.person_source_value = concat(scr_thoracic_patients.cleaned_nf_mrn, ' | ', scr_thoracic_patients.cleaned_nf_dob)
+--inner join image_occ on 
+-- seems duplicated --- double check 

--- a/src/sql/scr/thoracic/scr_thoracic_tb_image_occ.sql
+++ b/src/sql/scr/thoracic/scr_thoracic_tb_image_occ.sql
@@ -1,3 +1,8 @@
+
+-----------------------------------------------------------------------
+--- Number of pts with thoracic cancer, tb, and image occur records
+-----------------------------------------------------------------------
+
 with
 person as (select * from `@oncology_prod.@oncology_omop.person`),
 all_flag as (select * from `@oncology_prod.@oncology_temp.onc_arpah__cancer_cohort`),
@@ -24,4 +29,3 @@ tumor_board_patients tb
 inner join person_img on person_img.person_source_value = tb.person_source_value
 inner join scr_thoracic_patients on person_img.person_source_value = concat(scr_thoracic_patients.cleaned_nf_mrn, ' | ', scr_thoracic_patients.cleaned_nf_dob)
 --inner join image_occ on 
--- seems duplicated --- double check 

--- a/src/sql/scr/thoracic/scr_thoracic_tb_metrics.sql
+++ b/src/sql/scr/thoracic/scr_thoracic_tb_metrics.sql
@@ -1,3 +1,7 @@
+---------------------------------------------------
+--- number of pts with thoracic cancer and tb ----
+---------------------------------------------------
+
 with
 person as (select * from `@oncology_prod.@oncology_omop.person`),
 all_flag as (select * from `@oncology_prod.@oncology_temp.onc_arpah__cancer_cohort`),

--- a/src/sql/scr/thoracic/scr_thoracic_tb_person_metrics.sql
+++ b/src/sql/scr/thoracic/scr_thoracic_tb_person_metrics.sql
@@ -21,3 +21,5 @@ from
 tumor_board_patients tb
 inner join person on person.person_source_value = tb.person_source_value
 inner join scr_thoracic_patients on person.person_source_value = concat(scr_thoracic_patients.cleaned_nf_mrn, ' | ', scr_thoracic_patients.cleaned_nf_dob)
+
+-- seems duplicated --- double check 


### PR DESCRIPTION
@hmorgancooper please check the sql logics under imag_occ folder. I have added metrics for N(%) the series and pts for modality type and anatomic site. Please suggest if any other metric will be interesting to add. 

The outputs are all hided except for the text summary. 
